### PR TITLE
Force keyboard connection if flag true and if focused

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4586,7 +4586,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         switch (event.kind) {
           case ui.PointerDeviceKind.touch:
             if (kIsWeb) {
-              if(widget.persistKeyboardOnTapOutside) {
+              if(widget.persistKeyboardOnTapOutside && widget.focusNode.hasFocus) {
                 _forceInputConnection();
               } else {
                 widget.focusNode.unfocus();


### PR DESCRIPTION
- If persistKeyboardOnTapOutside is true and textfield is focused, do not hide when tapping outside.
- In this scenario to hide and lose focus call `_controller.closeInputConnection();`